### PR TITLE
refactor(Order): change foreign key relationship

### DIFF
--- a/src/main/java/com/fdmgroup/forex/DataLoader.java
+++ b/src/main/java/com/fdmgroup/forex/DataLoader.java
@@ -15,6 +15,7 @@ import com.fdmgroup.forex.enums.OrderStatus;
 import com.fdmgroup.forex.enums.OrderType;
 import com.fdmgroup.forex.models.Currency;
 import com.fdmgroup.forex.models.Order;
+import com.fdmgroup.forex.models.Portfolio;
 import com.fdmgroup.forex.models.Role;
 import com.fdmgroup.forex.models.User;
 import com.fdmgroup.forex.repos.*;
@@ -40,14 +41,16 @@ public class DataLoader implements ApplicationRunner {
 	private UserRepo userRepo;
 	private OrderRepo orderRepo;
 	private CurrencyRepo currencyRepo;
+	private PortfolioRepo portfolioRepo;
 
 	public DataLoader(PasswordEncoder pwdEncoder, RoleRepo roleRepo, UserRepo userRepo, OrderRepo orderRepo,
-			CurrencyRepo currencyRepo) {
+			CurrencyRepo currencyRepo, PortfolioRepo portfolioRepo) {
 		this.pwdEncoder = pwdEncoder;
 		this.roleRepo = roleRepo;
 		this.userRepo = userRepo;
 		this.orderRepo = orderRepo;
 		this.currencyRepo = currencyRepo;
+		this.portfolioRepo = portfolioRepo;
 	}
 
 	@Override
@@ -79,11 +82,13 @@ public class DataLoader implements ApplicationRunner {
 					pwdEncoder.encode("sampleuserpassword"), hkd, "sample_bank_account", role));
 		});
 
+		Portfolio portfolio = portfolioRepo.save(new Portfolio(user));
+
 		Calendar calendar = Calendar.getInstance();
 		calendar.add(Calendar.WEEK_OF_YEAR, 1);
 		Date oneWeekFromNow = calendar.getTime();
 		if (orderRepo.findByUser_Id(user.getId()).size() == 0) {
-			orderRepo.save(new Order(user, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, oneWeekFromNow, hkd, usd,
+			orderRepo.save(new Order(portfolio, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, oneWeekFromNow, hkd, usd,
 					7800, 7800, 1000));
 		}
 	}

--- a/src/main/java/com/fdmgroup/forex/DataLoader.java
+++ b/src/main/java/com/fdmgroup/forex/DataLoader.java
@@ -82,14 +82,17 @@ public class DataLoader implements ApplicationRunner {
 					pwdEncoder.encode("sampleuserpassword"), hkd, "sample_bank_account", role));
 		});
 
-		Portfolio portfolio = portfolioRepo.save(new Portfolio(user));
+		Portfolio portfolio = portfolioRepo.findByUser_Id(user.getId()).orElseGet(() -> {
+			return portfolioRepo.save(new Portfolio(user));
+		});
 
 		Calendar calendar = Calendar.getInstance();
 		calendar.add(Calendar.WEEK_OF_YEAR, 1);
 		Date oneWeekFromNow = calendar.getTime();
-		if (orderRepo.findByUser_Id(user.getId()).size() == 0) {
-			orderRepo.save(new Order(portfolio, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, oneWeekFromNow, hkd, usd,
-					7800, 7800, 1000));
+		if (orderRepo.findByPortfolio_User_Id(user.getId()).size() == 0) {
+			orderRepo.save(
+					new Order(portfolio, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, oneWeekFromNow, hkd, usd,
+							7800, 7800, 1000));
 		}
 	}
 

--- a/src/main/java/com/fdmgroup/forex/models/Order.java
+++ b/src/main/java/com/fdmgroup/forex/models/Order.java
@@ -22,8 +22,8 @@ public class Order {
     private UUID id;
 
     @ManyToOne()
-    @JoinColumn(name = "FK_User_ID", nullable = false, updatable = false)
-    private User user;
+    @JoinColumn(name = "FK_Portfolio_ID", nullable = false, updatable = false)
+    private Portfolio portfolio;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, updatable = false)
@@ -69,10 +69,10 @@ public class Order {
     public Order() {}
 
     public Order(
-        User user, OrderType orderType, OrderSide orderSide, OrderStatus orderStatus, Date expiryDate, 
+        Portfolio portfolio, OrderType orderType, OrderSide orderSide, OrderStatus orderStatus, Date expiryDate,
         Currency baseFx, Currency quoteFx, double total, double residual
     ) {
-        this.user = user;
+        this.portfolio = portfolio;
         this.orderType = orderType;
         this.orderSide = orderSide;
         this.orderStatus = orderStatus;
@@ -84,10 +84,10 @@ public class Order {
     }
 
     public Order(
-        User user, OrderType orderType, OrderSide orderSide, OrderStatus orderStatus, Date expiryDate, 
+        Portfolio portfolio, OrderType orderType, OrderSide orderSide, OrderStatus orderStatus, Date expiryDate,
         Currency baseFx, Currency quoteFx, double total, double residual, double limit
     ) {
-		this(user, orderType, orderSide, orderStatus, expiryDate, baseFx, quoteFx, total, residual);
+		this(portfolio, orderType, orderSide, orderStatus, expiryDate, baseFx, quoteFx, total, residual);
         setLimit(limit);
     }
 
@@ -101,13 +101,13 @@ public class Order {
         }
     }
 
-    public User getUser() {
-        return user;
+    public Portfolio getPortfolio() {
+        return portfolio;
     }
 
-    public void setUser(User user) {
-        if (user != null) {
-            this.user = user;
+    public void setPortfolio(Portfolio portfolio) {
+        if (portfolio != null) {
+            this.portfolio = portfolio;
         }
     }
 

--- a/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
+++ b/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.fdmgroup.forex.enums.OrderStatus;
@@ -14,12 +13,8 @@ import com.fdmgroup.forex.models.Order;
 @Repository
 public interface OrderRepo extends JpaRepository<Order, UUID> {
 
-	@Query("SELECT o FROM Order o WHERE o.portfolio.user.id = :id")
-    List<Order> findByUser_Id(UUID id);
-
-	@Query("SELECT o FROM Order o WHERE o.portfolio.user.id = :userId AND o.orderStatus = :orderStatus")
-    List<Order> findByUser_IdAndOrderStatus(UUID userId, OrderStatus orderStatus);
-
+    List<Order> findByPortfolio_User_Id(UUID id);
+    List<Order> findByPortfolio_User_IdAndOrderStatus(UUID userId, OrderStatus orderStatus);
     List<Order> findByOrderStatus(OrderStatus orderStatus);
     List<Order> findByOrderType(OrderType orderType);
 

--- a/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
+++ b/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.fdmgroup.forex.enums.OrderStatus;
@@ -13,8 +14,12 @@ import com.fdmgroup.forex.models.Order;
 @Repository
 public interface OrderRepo extends JpaRepository<Order, UUID> {
 
+	@Query("SELECT o FROM Order o WHERE o.portfolio.user.id = :id")
     List<Order> findByUser_Id(UUID id);
+
+	@Query("SELECT o FROM Order o WHERE o.portfolio.user.id = :userId AND o.orderStatus = :orderStatus")
     List<Order> findByUser_IdAndOrderStatus(UUID userId, OrderStatus orderStatus);
+
     List<Order> findByOrderStatus(OrderStatus orderStatus);
     List<Order> findByOrderType(OrderType orderType);
 

--- a/src/main/java/com/fdmgroup/forex/services/OrderService.java
+++ b/src/main/java/com/fdmgroup/forex/services/OrderService.java
@@ -32,12 +32,12 @@ public class OrderService {
     }
 
     public List<Order> findOrdersByUserId(UUID userId) {
-        List<Order> orders = orderRepo.findByUser_Id(userId);
+        List<Order> orders = orderRepo.findByPortfolio_User_Id(userId);
         return orders;
     }
 
     public List<Order> findOrdersByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus) {
-        List<Order> orders = orderRepo.findByUser_IdAndOrderStatus(userId, orderStatus);
+        List<Order> orders = orderRepo.findByPortfolio_User_IdAndOrderStatus(userId, orderStatus);
         return orders;
     }
 

--- a/src/test/java/com/fdmgroup/forex/models/OrderTest.java
+++ b/src/test/java/com/fdmgroup/forex/models/OrderTest.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 public class OrderTest {
 
-    private User user;
+    private Portfolio portfolio;
     private Currency baseFx;
     private Currency quoteFx;
     private Order order;
@@ -23,18 +23,18 @@ public class OrderTest {
     
     @BeforeEach
     public void setUp() {
-        user = mock(User.class);
+        portfolio = mock(Portfolio.class);
         baseFx = new Currency("USD", "U.S. Dollars");
         quoteFx = new Currency("EUR", "Euros");
         expiryDate = new Date();
-        order = new Order(user, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, expiryDate, baseFx, quoteFx, 1000, 500);
+        order = new Order(portfolio, OrderType.LIMIT, OrderSide.BUY, OrderStatus.ACTIVE, expiryDate, baseFx, quoteFx, 1000, 500);
     }
 
     @Test
     public void testOrder_DefaultConstructor() {
         Order defaultOrder = new Order();
         assertNull(defaultOrder.getId(), "Order ID should be null");
-        assertNull(defaultOrder.getUser(), "Order user should be null");
+        assertNull(defaultOrder.getPortfolio(), "Order portfolio should be null");
         assertNull(defaultOrder.getBaseFx(), "Order base currency should be null");
         assertNull(defaultOrder.getQuoteFx(), "Order quote currency should be null");
         assertNull(defaultOrder.getCreationDate(), "Order creation date should be null");
@@ -42,8 +42,8 @@ public class OrderTest {
 
     @Test
     public void testOrder_ParameterizedConstructor() {
-        assertNotNull(order.getUser(), "Order user should not be null");
-        assertEquals(user, order.getUser(), "Order user should match");
+        assertNotNull(order.getPortfolio(), "Order portfolio should not be null");
+        assertEquals(portfolio, order.getPortfolio(), "Order portfolio should match");
         assertEquals(OrderType.LIMIT, order.getOrderType(), "Order type should be LIMIT");
         assertEquals(OrderSide.BUY, order.getOrderSide(), "Order side should be BUY");
         assertEquals(OrderStatus.ACTIVE, order.getOrderStatus(), "Order status should be ACTIVE");
@@ -57,12 +57,12 @@ public class OrderTest {
     public void testSettersAndGetters() {
         Order order = new Order();
         UUID newId = UUID.randomUUID();
-        User newUser = mock(User.class);
+        Portfolio newPortfolio = mock(Portfolio.class);
         Currency newBaseFx = new Currency("GBP", "British Pound");
         Currency newQuoteFx = new Currency("JPY", "Japanese Yen");
 
         order.setId(newId);
-        order.setUser(newUser);
+        order.setPortfolio(newPortfolio);
         order.setBaseFx(newBaseFx);
         order.setQuoteFx(newQuoteFx);
         order.setTotal(2000);
@@ -70,7 +70,7 @@ public class OrderTest {
         order.setLimit(1.25);
 
         assertEquals(newId, order.getId(), "Order ID should match");
-        assertEquals(newUser, order.getUser(), "Order user should match");
+        assertEquals(newPortfolio, order.getPortfolio(), "Order portfolio should match");
         assertEquals(newBaseFx, order.getBaseFx(), "Order base currency should match");
         assertEquals(newQuoteFx, order.getQuoteFx(), "Order quote currency should match");
         assertEquals(2000, order.getTotal(), "Order total should match");
@@ -83,12 +83,12 @@ public class OrderTest {
         UUID validUUID = UUID.randomUUID();
         order.setId(validUUID);
         order.setId(null);
-        order.setUser(null);
+        order.setPortfolio(null);
         order.setBaseFx(null);
         order.setQuoteFx(null);
 
         assertEquals(validUUID, order.getId(), "Order ID should be unchanged");
-        assertEquals(user, order.getUser(), "Order user should be unchanged");
+        assertEquals(portfolio, order.getPortfolio(), "Order portfolio should be unchanged");
         assertEquals(baseFx, order.getBaseFx(), "Order base currency should be unchanged");
         assertEquals(quoteFx, order.getQuoteFx(), "Order quote currency should be unchanged");
     }

--- a/src/test/java/com/fdmgroup/forex/services/OrderServiceTest.java
+++ b/src/test/java/com/fdmgroup/forex/services/OrderServiceTest.java
@@ -79,36 +79,36 @@ public class OrderServiceTest {
 
     @Test
     void testFindOrdersByUserId_WhenOrdersExist() {
-        when(orderRepo.findByUser_Id(userId)).thenReturn(orders);
+        when(orderRepo.findByPortfolio_User_Id(userId)).thenReturn(orders);
         List<Order> foundOrders = orderService.findOrdersByUserId(userId);
         assertEquals(orders, foundOrders, "OrderService should find orders by a valid user ID");
-        verify(orderRepo, times(1)).findByUser_Id(userId);
+        verify(orderRepo, times(1)).findByPortfolio_User_Id(userId);
     }
 
     @Test
     void testFindOrdersByUserId_WhenNoOrdersExist() {
-        when(orderRepo.findByUser_Id(userId)).thenReturn(new ArrayList<>());
+        when(orderRepo.findByPortfolio_User_Id(userId)).thenReturn(new ArrayList<>());
         List<Order> foundOrders = orderService.findOrdersByUserId(userId);
         assertTrue(foundOrders.isEmpty(), "OrderService should return an empty list if no orders exist for a user");
-        verify(orderRepo, times(1)).findByUser_Id(userId);
+        verify(orderRepo, times(1)).findByPortfolio_User_Id(userId);
     }
 
     @Test
     void testFindOrdersByUserIdAndOrderStatus_WhenOrdersExist() {
         OrderStatus status = OrderStatus.ACTIVE;
-        when(orderRepo.findByUser_IdAndOrderStatus(userId, status)).thenReturn(orders);
+        when(orderRepo.findByPortfolio_User_IdAndOrderStatus(userId, status)).thenReturn(orders);
         List<Order> foundOrders = orderService.findOrdersByUserIdAndOrderStatus(userId, status);
         assertEquals(orders, foundOrders, "OrderService should find orders by user ID and order status");
-        verify(orderRepo, times(1)).findByUser_IdAndOrderStatus(userId, status);
+        verify(orderRepo, times(1)).findByPortfolio_User_IdAndOrderStatus(userId, status);
     }
 
     @Test
     void testFindOrdersByUserIdAndOrderStatus_WhenNoOrdersExist() {
         OrderStatus status = OrderStatus.ACTIVE;
-        when(orderRepo.findByUser_IdAndOrderStatus(userId, status)).thenReturn(new ArrayList<>());
+        when(orderRepo.findByPortfolio_User_IdAndOrderStatus(userId, status)).thenReturn(new ArrayList<>());
         List<Order> foundOrders = orderService.findOrdersByUserIdAndOrderStatus(userId, status);
         assertTrue(foundOrders.isEmpty(), "OrderService should return an empty list if no orders match the user ID and order status");
-        verify(orderRepo, times(1)).findByUser_IdAndOrderStatus(userId, status);
+        verify(orderRepo, times(1)).findByPortfolio_User_IdAndOrderStatus(userId, status);
     }
 
     @Test


### PR DESCRIPTION
Now an order is related to a portfolio instead of a user entity. Because
settlement should be made with a specific portfolio that is holding
actual assets, rather a user.