### PR TITLE
feat: order API and serialization

### DIFF
--- a/src/main/java/com/fdmgroup/forex/controllers/OrderController.java
+++ b/src/main/java/com/fdmgroup/forex/controllers/OrderController.java
@@ -32,6 +32,23 @@ public class OrderController {
         return ResponseEntity.ok(orders);
     }
 
+    @GetMapping("/portfolio/{id}")
+    public ResponseEntity<List<Order>> getOrdersByPortfolioIdAndOptionalOrderStatus(
+        @PathVariable UUID id, 
+        @RequestParam(required = false) OrderStatus orderStatus
+    ) {
+        List<Order> orders;
+        if (orderStatus == null) {
+            orders = orderService.findOrdersByPortfolioId(id);
+        } else {
+            orders = orderService.findOrdersByPortfolioIdAndOrderStatus(id, orderStatus);
+        }
+        if (orders.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        return ResponseEntity.ok(orders);
+    }
+
     @GetMapping("/status/{orderStatus}")
     public ResponseEntity<List<Order>> getOrdersByOrderStatus(@PathVariable OrderStatus orderStatus) {
         List<Order> orders = orderService.findOrdersByOrderStatus(orderStatus);

--- a/src/main/java/com/fdmgroup/forex/models/Order.java
+++ b/src/main/java/com/fdmgroup/forex/models/Order.java
@@ -5,9 +5,11 @@ import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fdmgroup.forex.enums.OrderSide;
 import com.fdmgroup.forex.enums.OrderStatus;
 import com.fdmgroup.forex.enums.OrderType;
+import com.fdmgroup.forex.models.serializers.OrderSerializer;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Positive;
@@ -15,6 +17,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 
 @Entity
 @Table(name = "orders")
+@JsonSerialize(using = OrderSerializer.class)
 public class Order {
 
     @Id

--- a/src/main/java/com/fdmgroup/forex/models/dto/OrderResponseDTO.java
+++ b/src/main/java/com/fdmgroup/forex/models/dto/OrderResponseDTO.java
@@ -1,0 +1,100 @@
+package com.fdmgroup.forex.models.dto;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.fdmgroup.forex.enums.*;
+import com.fdmgroup.forex.models.Order;
+
+/**
+ * OrderResponseDTO
+ */
+public class OrderResponseDTO {
+
+	private UUID id;
+	private UUID portfolioId;
+	private UUID userId;
+	private OrderType orderType;
+	private OrderSide orderSide;
+	private OrderStatus orderStatus;
+	private Date creationDate;
+	private Date expiryDate;
+	private String baseFx; // currency code
+	private String quoteFx; // currency code
+	private double total;
+	private double residual;
+	private double limit;
+
+	public OrderResponseDTO(Order order) {
+		this.id = order.getId();
+		this.portfolioId = order.getPortfolio().getId();
+		this.orderType = order.getOrderType();
+		this.orderSide = order.getOrderSide();
+		this.orderStatus = order.getOrderStatus();
+		this.creationDate = order.getCreationDate();
+		this.expiryDate = order.getExpiryDate();
+		this.baseFx = order.getBaseFx().getCurrencyCode();
+		this.quoteFx = order.getQuoteFx().getCurrencyCode();
+		this.total = order.getTotal();
+		this.residual = order.getResidual();
+		this.limit = order.getLimit();
+	}
+
+	public OrderResponseDTO(Order order, UUID userId) {
+		this(order);
+		this.userId = userId;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public UUID getPortfolioId() {
+		return portfolioId;
+	}
+
+	public UUID getUserId() {
+		return userId;
+	}
+
+	public OrderType getOrderType() {
+		return orderType;
+	}
+
+	public OrderSide getOrderSide() {
+		return orderSide;
+	}
+
+	public OrderStatus getOrderStatus() {
+		return orderStatus;
+	}
+
+	public Date getCreationDate() {
+		return creationDate;
+	}
+
+	public Date getExpiryDate() {
+		return expiryDate;
+	}
+
+	public String getBaseFx() {
+		return baseFx;
+	}
+
+	public String getQuoteFx() {
+		return quoteFx;
+	}
+
+	public double getTotal() {
+		return total;
+	}
+
+	public double getResidual() {
+		return residual;
+	}
+
+	public double getLimit() {
+		return limit;
+	}
+
+}

--- a/src/main/java/com/fdmgroup/forex/models/serializers/OrderSerializer.java
+++ b/src/main/java/com/fdmgroup/forex/models/serializers/OrderSerializer.java
@@ -1,0 +1,20 @@
+package com.fdmgroup.forex.models.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fdmgroup.forex.models.Order;
+import com.fdmgroup.forex.models.dto.OrderResponseDTO;
+
+import java.io.IOException;
+
+public class OrderSerializer extends JsonSerializer<Order> {
+
+	@Override
+	public void serialize(Order order, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+			throws IOException {
+		OrderResponseDTO dto = new OrderResponseDTO(order, order.getPortfolio().getUser().getId());
+		jsonGenerator.writeObject(dto);
+	}
+
+}

--- a/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
+++ b/src/main/java/com/fdmgroup/forex/repos/OrderRepo.java
@@ -17,5 +17,7 @@ public interface OrderRepo extends JpaRepository<Order, UUID> {
     List<Order> findByPortfolio_User_IdAndOrderStatus(UUID userId, OrderStatus orderStatus);
     List<Order> findByOrderStatus(OrderStatus orderStatus);
     List<Order> findByOrderType(OrderType orderType);
+    List<Order> findByPortfolio_IdAndOrderStatus(UUID id, OrderStatus orderStatus);
+    List<Order> findByPortfolio_Id(UUID id);
 
 }

--- a/src/main/java/com/fdmgroup/forex/services/OrderService.java
+++ b/src/main/java/com/fdmgroup/forex/services/OrderService.java
@@ -51,4 +51,14 @@ public class OrderService {
         return orders;
     }
 
+    public List<Order> findOrdersByPortfolioId(UUID portfolioId) {
+        List<Order> orders = orderRepo.findByPortfolio_Id(portfolioId);
+        return orders;
+    }
+
+    public List<Order> findOrdersByPortfolioIdAndOrderStatus(UUID portfolioId, OrderStatus orderStatus) {
+        List<Order> orders = orderRepo.findByPortfolio_IdAndOrderStatus(portfolioId, orderStatus);
+        return orders;
+    }
+
 }


### PR DESCRIPTION
- Set a custom default serialization strategy to Order entity. Now an order is serialized into:
  ```JSON
  [
    {
        "id": "7ab7d8ae-8a56-430e-bb1b-682273acd700",
        "portfolioId": "113b09c8-aa3e-4971-bed6-2ce188cf1634",
        "userId": "11da1b6d-dcfe-4345-8bd0-9585174af043",
        "orderType": "LIMIT",
        "orderSide": "BUY",
        "orderStatus": "ACTIVE",
        "creationDate": "2024-09-10T15:37:52.071+00:00",
        "expiryDate": "2024-09-17T15:37:52.058+00:00",
        "baseFx": "HKD",
        "quoteFx": "USD",
        "total": 7800.0,
        "residual": 7800.0,
        "limit": 1000.0
    }
  ]
  ```
- Add API end point to get order records by portfolio ID and optionally order status